### PR TITLE
Site rendering issues

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -368,6 +368,14 @@ nav.foldable-nav {
 
   .td-sidebar__inner {
     padding-top: 0;
+
+    // Prevent sidebar from overlapping footer when using position: sticky.
+    // On desktop, constrain height so long nav scrolls within viewport.
+    @include media-breakpoint-up(lg) {
+      max-height: calc(100vh - 8rem);
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
   }
 
   .td-sidebar-nav {

--- a/site/layouts/partials/navbar-version-selector.html
+++ b/site/layouts/partials/navbar-version-selector.html
@@ -21,7 +21,7 @@
         {{ end -}}
         {{ $href := printf "%s%s" $url $path -}}
         {{ if ne $baseURL "/" }}
-        {{ $href := printf "%s%s%s" $baseURL $url $path -}}
+        {{ $href = printf "%s%s%s" $baseURL $url $path -}}
         {{ end }}
         <li><a class="dropdown-item" href="{{ $href }}">{{ $text }}</a></li>
         {{ end -}}

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -43,7 +43,7 @@
         {{ $pre := .Pre }}
         {{ $post := .Post }}
         {{ $url := urls.Parse .URL }}
-        {{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
+        {{ $baseurl := urls.Parse $.Site.BaseURL }}
         <a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"{{ if ne $url.Host $baseurl.Host }} target="_blank" rel="noopener"{{ end }}>{{ with .Pre}}{{ $pre }}{{ end }}<span{{if $active }} class="active"{{end}}>{{ .Name }}</span>{{ with .Post}}{{ $post }}{{ end }}</a>
       </li>
       {{ end }}

--- a/site/tools/benchmark-dashboard/src/components/ui/menubar.tsx
+++ b/site/tools/benchmark-dashboard/src/components/ui/menubar.tsx
@@ -212,7 +212,7 @@ const MenubarShortcut = ({
     />
   )
 }
-MenubarShortcut.displayname = "MenubarShortcut"
+MenubarShortcut.displayName = "MenubarShortcut"
 
 export {
   Menubar,


### PR DESCRIPTION
**What type of PR is this?**
fix(site): Fix site rendering issues, navbar links, and React component typo

**What this PR does / why we need it**:
This PR addresses several rendering and menu-related bugs identified in the `site` directory:
- Corrects base URL usage in `navbar.html` to properly detect external links.
- Fixes broken version selector links when the site is deployed to a subpath by adjusting variable scope in `navbar-version-selector.html`.
- Resolves a typo (`displayname` to `displayName`) in `menubar.tsx` for correct React DevTools display.

**Which issue(s) this PR fixes**:
Fixes #

Release Notes: No

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b5dead83-3ca2-40f7-9a01-ec9ed6ca7c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5dead83-3ca2-40f7-9a01-ec9ed6ca7c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

